### PR TITLE
codec_g72x.c: Convert lingering verbose to ast_debug.

### DIFF
--- a/codec_g72x.c
+++ b/codec_g72x.c
@@ -589,8 +589,7 @@ static struct ast_translator lintog72x = {
             if (!strcasecmp(var->name, "sendrate")) {
                 rate = atoi(var->value);
                 if (rate == 53 || rate == 63) {
-                    if (option_verbose > 2)
-                        ast_verbose(VERBOSE_PREFIX_3 "G.723.1 setting sendrate to %d\n", rate);
+                    ast_debug(5, "G.723.1 setting sendrate to %d\n", rate);
                     g723_sendrate = (rate == 63) ? G723_RATE_63 : G723_RATE_53;
                 } else {
                     ast_log(LOG_ERROR, "G.723.1 sendrate must be 53 or 63\n");


### PR DESCRIPTION
Commit f2313ea51ba11cf8763d52ef02d00c4ac5f719a5 converted most debug messages that were using from ast_verbose to ast_debug, but this one got missed.